### PR TITLE
docs: add daisuki to deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,5 @@ For searching specific anime, you can use [because.moe](http://because.moe/) (US
 
 | Streaming Site  | Country / Area  | Language |  Note  |
 | -------- | -------- | ------ | ---- |
-|[Daisuki](httpsDaisuki.net) | Worldwide | English sub | Discontinued in October 2017
+|[Daisuki](https://daisuki.net) | Worldwide | English sub | Discontinued in October 2017
 |[Ponimu](http://ponimu.com/) | Indonesia  | Indonesian subtitle | Discontinued in January 2020. 49000IDR per month. The anime line-up is consists of show from Hakuhodo DY / Showgate|


### PR DESCRIPTION
https://www.animenewsnetwork.com/news/2017-08-01/daisuki-ends-anime-streaming-service-in-october/.119596
https://www.animenewsnetwork.com/news/2019-12-17/indonesian-anime-streaming-service-ponimu-indonesia-shuts-down-in-january/.154462